### PR TITLE
DevContainer追加

### DIFF
--- a/.devcontainer/README-ja.md
+++ b/.devcontainer/README-ja.md
@@ -1,0 +1,54 @@
+# DevContainer セットアップ
+
+このDevContainerは、Python、Node.js、GitHub CLI、Claude Codeを含む開発環境を提供します。
+
+[English version](README.md)
+
+## 初回セットアップ
+
+コンテナ作成後、以下の認証が必要です：
+
+1. **GitHub CLI の認証**
+   ```bash
+   gh auth login
+   ```
+
+2. **Claude の認証**
+   ```bash
+   claude
+   ```
+
+## 含まれる機能
+
+- **Python 3.13** - 最新の Python 開発環境
+- **Node.js 20** - JavaScript/TypeScript 開発用
+- **GitHub CLI** - GitHub との統合
+- **Docker-in-Docker** - コンテナ内での Docker 操作
+- **Claude Code 拡張機能** - VSCode で Claude を使用可能
+
+## systemd について
+
+このDevContainer設定では、systemd は無効になっています。
+
+- systemd を有効にする場合は、Dockerfile等でENTRYPOINTによって起動するコンテナを使う必要があります
+- Docker-in-Docker のfeature は、systemd有効時には使えなくなる可能性があります
+- その場合は、別途 docker のインストールが必要になります
+
+## トラブルシューティング
+
+### Claude Code のインストールに失敗する場合
+
+手動でインストールしてください：
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+### 認証情報が失われた場合
+
+コンテナを再作成すると認証情報が失われるため、再度認証が必要になります：
+
+```bash
+gh auth login
+claude
+```

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,50 +1,52 @@
-# DevContainer セットアップ
+# DevContainer Setup
 
-このDevContainerは、Python、Node.js、GitHub CLI、Claude Codeを含む開発環境を提供します。
+This DevContainer provides a development environment with Python, Node.js, GitHub CLI, and Claude Code.
 
-## 初回セットアップ
+[日本語版はこちら](README-ja.md)
 
-コンテナ作成後、以下の認証が必要です：
+## Initial Setup
 
-1. **GitHub CLI の認証**
+After container creation, authentication is required:
+
+1. **GitHub CLI Authentication**
    ```bash
    gh auth login
    ```
 
-2. **Claude の認証**
+2. **Claude Authentication**
    ```bash
    claude
    ```
 
-## 含まれる機能
+## Included Features
 
-- **Python 3.14** - 最新の Python 開発環境
-- **Node.js 20** - JavaScript/TypeScript 開発用
-- **GitHub CLI** - GitHub との統合
-- **Docker-in-Docker** - コンテナ内での Docker 操作
-- **Claude Code 拡張機能** - VSCode で Claude を使用可能
+- **Python 3.13** - Latest Python development environment
+- **Node.js 20** - For JavaScript/TypeScript development
+- **GitHub CLI** - GitHub integration
+- **Docker-in-Docker** - Docker operations within the container
+- **Claude Code Extension** - Use Claude in VSCode
 
-## systemd について
+## About systemd
 
-このDevContainer設定では、systemd は無効になっています。
+systemd is disabled in this DevContainer configuration.
 
-- systemd を有効にする場合は、Dockerfile等でENTRYPOINTによって起動するコンテナを使う必要があります
-- Docker-in-Docker のfeature は、systemd有効時には使えなくなる可能性があります
-- その場合は、別途 docker のインストールが必要になります
+- To enable systemd, you need to use a container that starts via ENTRYPOINT in a Dockerfile
+- The Docker-in-Docker feature may not work when systemd is enabled
+- In such cases, separate Docker installation is required
 
-## トラブルシューティング
+## Troubleshooting
 
-### Claude Code のインストールに失敗する場合
+### If Claude Code Installation Fails
 
-手動でインストールしてください：
+Install manually:
 
 ```bash
 npm install -g @anthropic-ai/claude-code
 ```
 
-### 認証情報が失われた場合
+### If Authentication is Lost
 
-コンテナを再作成すると認証情報が失われるため、再度認証が必要になります：
+When the container is recreated, authentication is lost and re-authentication is required:
 
 ```bash
 gh auth login

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/base:jammy",
 	"features": {
-		"ghcr.io/devcontainers/features/python:1": { "version": "3.14" },
+		"ghcr.io/devcontainers/features/python:1": { "version": "3.13" },
 		"ghcr.io/devcontainers/features/node:1": { "version": "20" },
 		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {}

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -7,12 +7,12 @@ echo "Installing Claude Code..."
 if npm install -g @anthropic-ai/claude-code; then
     echo "✓ Claude Code installed successfully"
 else
-    echo "✗ Failed to install Claude Code. Please install manually."
-    exit 1
+    echo "✗ Failed to install Claude Code. Please install manually with: npm install -g @anthropic-ai/claude-code"
+    echo "Continuing with container setup..."
 fi
 
 echo "Verifying installation..."
-claude --version || echo "Claude installed but may need authentication"
+claude --version || echo "⚠️  Claude installed but requires authentication. Run 'claude' to authenticate."
 
 echo ""
 echo "⚠️  Post-setup required:"


### PR DESCRIPTION
systemd は無効です。
systemd を有効にする場合は、Dockerfile等でENTRYPOINTによって起動するコンテナを使う必要があります。
また、Docker-in-Docker のfeature は使えなくなるようなので、別途 docker のインストールが必要になります。

コンテナ作成・再作成時には、claude および gh auth login での認証が必要になります。